### PR TITLE
fix(docs): improve mobile layout of test client

### DIFF
--- a/docs/test-client.html
+++ b/docs/test-client.html
@@ -63,12 +63,12 @@
       #structuredCTA{flex:1 1 auto}
       /* スマホ版のレスポンシブデザイン */
       @media (max-width: 980px){
-        main{grid-template-columns:1fr; padding:8px; gap:8px}
+        main{grid-template-columns:1fr; padding:8px; gap:8px; height:auto; overflow:visible}
+        .section{padding:16px; gap:12px; overflow:visible; min-height:auto}
         .split{grid-template-columns:1fr; gap:8px}
         header{padding:12px 16px; flex-wrap:wrap; gap:8px}
         header h1{font-size:18px; flex:1; min-width:200px}
         .card h2{font-size:14px; padding:12px 16px}
-        .section{padding:16px; gap:12px}
         .toolbar{flex-direction:column; align-items:stretch; gap:8px}
         .toolbar .grow{width:100%}
         input[type=text], select{padding:12px; font-size:16px; border-radius:12px}
@@ -84,11 +84,11 @@
       
       /* スマホ版のタッチフレンドリーな改善 */
       @media (max-width: 768px){
-        main{padding:6px; gap:6px; height:calc(100vh - 80px)}
+        main{padding:6px; gap:6px; height:auto; overflow:visible}
+        .section{padding:20px; gap:16px; overflow:visible; min-height:auto}
         header{padding:10px 12px; border-bottom-width:2px}
         .card{border-radius:16px; border-width:2px}
         .card h2{padding:16px; font-size:16px; font-weight:600}
-        .section{padding:20px; gap:16px}
         .toolbar{flex-direction:column; gap:12px}
         .btn{min-height:56px; font-size:16px; font-weight:500; box-shadow:0 2px 8px rgba(0,0,0,0.1)}
         .btn:active{transform:translateY(1px); box-shadow:0 1px 4px rgba(0,0,0,0.1)}
@@ -116,23 +116,24 @@
       
       /* 超小型スマホ対応 */
       @media (max-width: 480px){
+        main{height:auto; overflow:visible}
+        .section{padding:16px; gap:12px; overflow:visible; min-height:auto}
         header{padding:8px 10px}
         header h1{font-size:16px; min-width:150px}
-        .section{padding:16px; gap:12px}
         .toolbar{gap:10px}
         .btn{min-height:52px; padding:10px 14px}
         input[type=text], select{min-height:52px; padding:10px 14px}
         .list .item{min-height:60px; padding:10px 14px}
         .json-box{min-height:250px}
-        
+
         /* 超小型スマホでのタブ */
         .tab-container{padding:4px; gap:4px}
         .tab-container .btn{padding:6px 12px; font-size:13px; min-height:36px}
-        
+
         /* 超小型スマホでのチップ */
         .chips{gap:6px}
         .chip{padding:6px 10px; font-size:13px}
-        
+
         /* 超小型スマホでのCTA */
         .cta{padding:20px}
         .cta button{min-height:56px; font-size:15px}


### PR DESCRIPTION
## Summary
- enable scrolling and remove fixed heights on small screens for the test client
- allow sections to expand naturally on phones

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68984c69c3bc832781619ace2282ad78